### PR TITLE
Remove the before and after steps

### DIFF
--- a/lib/visiflow/workflow.rb
+++ b/lib/visiflow/workflow.rb
@@ -42,18 +42,6 @@ module Visiflow::Workflow
     assert_all_steps_defined
   end
 
-  def before_step(step)
-    method_name = "before_#{step}"
-    return send(method_name) if respond_to? method_name
-    true
-  end
-
-  def after_step(step, result)
-    method_name = "after_#{step}"
-    return send(method_name, result) if respond_to? method_name
-    result
-  end
-
   def around_step(_step_name)
     yield
   end
@@ -64,12 +52,10 @@ module Visiflow::Workflow
 
     # probably should pass in the args to the around and before steps as well.
     around_step(step.name) do
-      if before_step(step.name)
-        result = send(step.name, *args)
-        fail BAD_STEP_RESPONSE unless result.is_a? Visiflow::Response
-        update_context(result.values)
-        after_step(step.name, result)
-      end
+      result = send(step.name, *args)
+      fail BAD_STEP_RESPONSE unless result.is_a? Visiflow::Response
+      update_context(result.values)
+      result
     end
   end
 

--- a/spec/lib/visiflow/workflow_spec.rb
+++ b/spec/lib/visiflow/workflow_spec.rb
@@ -8,34 +8,6 @@ describe Visiflow::Workflow do
     Then  { result.is_a? TestWorkflow }
   end
 
-  describe 'before_step' do
-    context 'when a before_step is defined' do
-      When(:response) { workflow.before_step(:step1) }
-      Then { workflow.before_step1_called.should be true }
-    end
-
-    context 'when a before_step is NOT defined' do
-      When(:response) { workflow.before_step(:step2) }
-      Then { response == true } # to prevent canceling the workflow
-    end
-  end
-
-  describe 'after_step' do
-    context 'when a after_step is defined' do
-      When(:response) do
-        workflow.after_step(:step1, Visiflow::Response.success)
-      end
-      Then { workflow.after_step1_called.should be true }
-    end
-
-    context 'when a after_step is NOT defined' do
-      When(:response) do
-        workflow.after_step(:step2, Visiflow::Response.success)
-      end
-      Then { response.success? } # to prevent canceling the workflow
-    end
-  end
-
   describe 'run' do
     context "when all steps' results are success" do
       When(:ran_workflow) { workflow.run }


### PR DESCRIPTION
These methods never were used and made the code more complicated.

If someone really needs before/after functionality, they can add another
step or hook into the around_step method.
